### PR TITLE
arreglo de bug en definicion del form para que envie adjuntos

### DIFF
--- a/punto4-v3/model/ap.model.php
+++ b/punto4-v3/model/ap.model.php
@@ -250,6 +250,26 @@ class Appointment
             $booleano= false;
         }
 
+        echo "<pre>";
+        var_dump($_FILES);
+        /*
+            array(1) {
+              ["adjunto"]=>
+              array(5) {
+                ["name"]=>
+                string(31) "http-request-response-basic.png"
+                ["type"]=>
+                string(9) "image/png" <- COMPAREN CONTRA ESTE CAMPO
+                ["tmp_name"]=>
+                string(14) "/tmp/phpeiU9V1"
+                ["error"]=>
+                int(0)
+                ["size"]=>
+                int(20064)
+              }
+}
+        */
+
         var_dump($this->getAdjunto());
         if (!empty($this->getAdjunto())) {
 

--- a/punto4-v3/view/new.appointment.php
+++ b/punto4-v3/view/new.appointment.php
@@ -17,7 +17,7 @@
         </nav>
     </header>
     <main>
-        <form action="/save_appointment" method="post">
+        <form action="/save_appointment" method="post" enctype="multipart/form-data">
             <label> Nombre: <input type="text" name="nombre" minlength="3" maxlength="30" required pattern="[A-Za-z]+"> </label><br>
             <label> Email:  <input type="email" name="email" required> </label><br>
             <label> Telefono: <input type="tel" name="telefono" required> </label><br>


### PR DESCRIPTION
Para validar el tipo de archivo, a los fines de nuestro TP, alcanza con que comparen el campo

$_FILES['adjunto']['type'] contra los string de tipo valido ("image/png", "image/jpg", "image/jpeg").

Se los deje commentado en el commit para que lo vean.

Ademas tenian un bug en el html, no estaban enviando el archivo. Tambien se los deje andando.